### PR TITLE
Sigmode

### DIFF
--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -484,7 +484,6 @@ Mend_PMP:                                    ;\
  /*SIGMODES using gcc -D SIGMODE_NONE for no Signiture -D SIGMODE_SELFCHECK for selfcheck(both do nothing, needs updating) NO -D for defualt Signitures*/
 
 /* Ensure SIGMODE_DEFAULT is defined if no SIGMODE is provided */ 
-#define SIGMODE_NONE
 #ifndef SIGMODE_NONE
 #ifndef SIGMODE_SELFCHECK
 #define SIGMODE_DEFAULT

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -473,9 +473,9 @@ Mend_PMP:                                    ;\
   .if (_PRE_INC!=0)					;\
     .set offset, offset+_SZ				;\
   .endif						;\
-  .if offset >= 2048					;\
-     addi   _BREG,  _BREG,   (2048 - _SZ)		;\
-     .set   offset, offset - (2048 - _SZ)		;\
+  .if offset >= 2032					;\
+    addi   _BREG,  _BREG,   2032 		;\
+    .set   offset, 0		;\
   .endif
 
  /* automatically adjust base and offset if offset gets too big, resetting offset				 */
@@ -522,7 +522,7 @@ Mend_PMP:                                    ;\
   .if (offset&(SIGALIGN-1))!=0				;\
 /* Throw warnings then modify offset to target */	;\
      .warning "Incorrect signature Offset Alignment."	;\
-     .set offset, offset&(SIGALIGN-1)+SIGALIGN		;\
+     .set offset, (offset&~(SIGALIGN-1))+SIGALIGN		;\
   .endif						;\
   CHK_OFFSET(_BR, SIGALIGN, 0)				;\
   FSREG _R,offset(_BR)					;\

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -467,7 +467,8 @@ Mend_PMP:                                    ;\
     sub  _AREG, _AREG, _TREG /* undo modification */ ;\
  .endif
   /* this function ensures individual sig stores don't exceed offset limits  */
-  /* if they would, update the base and reduce offset by 2048 - _SZ	     */
+  /* if they would, update the base by 2032 and reset the offset     */
+  /* exceed offset limit is 16 below basereg to allow for allignment across different register sizes and 2032 to avoid max 2048 add*/
   /* an option is to pre-incr offset if there was a previous signature store */
 #define CHK_OFFSET(_BREG, _SZ, _PRE_INC)		;\
   .if (_PRE_INC!=0)					;\

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -481,14 +481,35 @@ Mend_PMP:                                    ;\
  /* automatically adjust base and offset if offset gets too big, resetting offset				 */
  /* RVTEST_SIGUPD(basereg, sigreg)	  stores sigreg at offset(basereg) and updates offset by regwidth	 */
  /* RVTEST_SIGUPD(basereg, sigreg,newoff) stores sigreg at newoff(basereg) and updates offset to regwidth+newoff */
-#define RVTEST_SIGUPD(_BR,_R,...)			;\
-  .if NARG(__VA_ARGS__) == 1				;\
-	.set offset,_ARG1(__VA_OPT__(__VA_ARGS__,0))	;\
-  .endif						;\
-  CHK_OFFSET(_BR, REGWIDTH,0)				;\
-  SREG _R,offset(_BR)					;\
-  .set offset,offset+REGWIDTH
+ /*SIGMODES using gcc -D SIGMODE_NONE for no Signiture -D SIGMODE_SELFCHECK for selfcheck(both do nothing, needs updating) NO -D for defualt Signitures*/
 
+/* Ensure SIGMODE_DEFAULT is defined if no SIGMODE is provided */ 
+#define SIGMODE_NONE
+#ifndef SIGMODE_NONE
+#ifndef SIGMODE_SELFCHECK
+#define SIGMODE_DEFAULT
+#endif
+#endif
+
+#ifdef SIGMODE_NONE
+    #define RVTEST_SIGUPD(_BR, _R, ...) \
+        nop;
+#endif
+// SIGMODE_SELFCHECK: TODO
+#ifdef SIGMODE_SELFCHECK
+    #define RVTEST_SIGUPD(_BR, _R, ...) \
+        nop /* TODO: Add self-check logic here */;
+#endif
+// SIGMODE_DEFAULT: Default behavior
+#ifdef SIGMODE_DEFAULT
+    #define RVTEST_SIGUPD(_BR, _R, ...)                \
+        .if NARG(__VA_ARGS__) == 1				;\
+        .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,0))	;\
+        .endif						;\
+        CHK_OFFSET(_BR, REGWIDTH,0)				;\
+        SREG _R,offset(_BR)					;\
+        .set offset,offset+REGWIDTH   
+#endif  
 /* RVTEST_SIGUPD_F(basereg, sigreg,flagreg,newoff)			 */
 /* This macro is used to store the signature values of (32 & 64) F and D */
 /* teats which use TEST_(FPSR_OP, FPIO_OP, FPRR_OP, FPR4_OP) opcodes	 */
@@ -509,7 +530,7 @@ Mend_PMP:                                    ;\
   CHK_OFFSET(_BR, SIGALIGN, 1)				;\
   SREG _F,offset(_BR)					;\
   .set offset,offset+SIGALIGN
- 
+
 /* RVTEST_SIGUPD_FID(basereg, sigreg,flagreg,newoff)			*/
 /* This macro stores the signature values of (32 & 64) F & D insts	*/
 /* which uses TEST_(FPID_OP, FCMP_OP) ops				*/

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -468,7 +468,8 @@ Mend_PMP:                                    ;\
  .endif
   /* this function ensures individual sig stores don't exceed offset limits  */
   /* if they would, update the base by 2032 and reset the offset     */
-  /* exceed offset limit is 16 below basereg to allow for allignment across different register sizes and 2032 to avoid max 2048 add*/
+  /* exceed offset limit is 16 below Breg-add # to allow for allignment across different register sizes */
+  /* 2032 as Breg add amount to avoid max 2048 add*/
   /* an option is to pre-incr offset if there was a previous signature store */
 #define CHK_OFFSET(_BREG, _SZ, _PRE_INC)		;\
   .if (_PRE_INC!=0)					;\

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -473,7 +473,7 @@ Mend_PMP:                                    ;\
   .if (_PRE_INC!=0)					;\
     .set offset, offset+_SZ				;\
   .endif						;\
-  .if offset >= 2032					;\
+  .if offset >= 2016					;\
     addi   _BREG,  _BREG,   2032 		;\
     .set   offset, 0		;\
   .endif


### PR DESCRIPTION
Adjusted macro RVTEST_SIGUPD in test_macros.h for groundwork of different SIGMODES with normal macro as default. 

expecting SIGMODES: SIGMODE_NONE, SIGMODE_SELFCHECK, and SIGMODE_DEFAULT. expected to be used during gcc compile with -D

From Prof. Harris verbal comment yesterday may need to adjust nop count to keep macro instructions the same across SIGMODES (as I understood)