### PR TITLE
Modified test_macros_vector.h to make sigReg rotatable

### DIFF
--- a/riscv-test-suite/env/test_macros_vector.h
+++ b/riscv-test-suite/env/test_macros_vector.h
@@ -58,14 +58,16 @@
     vle ## SEW ##.v
 
 // RVTEST_SIGUPD_V() stores the contests of a vector register in the signature
+// _BR is basereg, not hard coded to account for VX instructions
+// _TMPR is the original HELPER_GPR, used as a scratch register
 // AVL is the application vector length
 // SEW defines the element size in bits (8, 16, 32, or 64)
 // VREG is a VR that holds the data
 // offset will be updated (to the next 8-byte boundary)
-#define RVTEST_SIGUPD_V(AVL, SEW, VREG)                                 \
-    CHK_OFFSET(SIG_BASE, REGWIDTH, 0) ;                                 \
-    addi HELPER_GPR, SIG_BASE, offset ;                                 \
-    vse ## SEW ##.v VREG, (HELPER_GPR) ;                                \
+#define RVTEST_SIGUPD_V(_BR, _TMPR, AVL, SEW, VREG)                                 \
+    CHK_OFFSET(_BR, REGWIDTH, 0) ;                                 \
+    addi _TMPR, _BR, offset ;                                 \
+    vse ## SEW ##.v VREG, (_TMPR) ;                                \
     .set offset, offset + (AVL * SEW / 8) ;                             \
     .if (offset & 7) > 0 ;                                              \
     .set offset, (offset + 8) & ~7 ;                                    \

--- a/riscv-test-suite/env/test_macros_vector.h
+++ b/riscv-test-suite/env/test_macros_vector.h
@@ -111,7 +111,7 @@
     addi HELPER_GPR, DATA_BASE, DOFF2 ;                                 \
     VLE(SEW) VS2, (HELPER_GPR) ;                                        \
     VINST VD, VS2 ;                                                     \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_VV_M() runs a single masked vector instruction test.
@@ -135,7 +135,7 @@
     VLE(SEW) VS2, (HELPER_GPR) ;                                        \
     vxor.vv VD, VD, VD ;                                                \
     VINST VD, VS2, v0.t ;                                               \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_WV() runs a single vector instruction test.
@@ -159,7 +159,7 @@
     addi HELPER_GPR, DATA_BASE, DOFF ;                                  \
     VLE(SEW) VD, (HELPER_GPR) ;                                         \
     VINST VD, VS2 ;                                                     \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_VVR() runs a single vector instruction test.
@@ -183,7 +183,7 @@
     addi HELPER_GPR, DATA_BASE, DOFF1 ;                                 \
     LREG RS1, (HELPER_GPR) ;                                            \
     VINST VD, VS2, RS1 ;                                                \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_VVR_M() runs a single masked vector instruction test.
@@ -209,7 +209,7 @@
     LREG RS1, (HELPER_GPR) ;                                            \
     vxor.vv VD, VD, VD ;                                                \
     VINST VD, VS2, RS1, v0.t ;                                          \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_VVU() runs a single vector instruction test.
@@ -231,7 +231,7 @@
     addi HELPER_GPR, DATA_BASE, DOFF2 ;                                 \
     VLE(SEW) VS2, (HELPER_GPR) ;                                        \
     VINST VD, VS2, UIMM ;                                               \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_VVU_M() runs a single masked vector instruction test.
@@ -255,7 +255,7 @@
     VLE(SEW) VS2, (HELPER_GPR) ;                                        \
     vxor.vv VD, VD, VD ;                                                \
     VINST VD, VS2, UIMM, v0.t ;                                         \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_WVU() runs a single vector instruction test.
@@ -279,7 +279,7 @@
     addi HELPER_GPR, DATA_BASE, DOFF ;                                  \
     VLE(SEW) VD, (HELPER_GPR) ;                                         \
     VINST VD, VS2, UIMM ;                                               \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_VVV() runs a single vector instruction test.
@@ -303,7 +303,7 @@
     addi HELPER_GPR, DATA_BASE, DOFF1 ;                                 \
     VLE(SEW) VS1, (HELPER_GPR) ;                                        \
     VINST VD, VS2, VS1 ;                                                \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_VVV_M() runs a single masked vector instruction test.
@@ -329,7 +329,7 @@
     VLE(SEW) VS1, (HELPER_GPR) ;                                        \
     vxor.vv VD, VD, VD ;                                                \
     VINST VD, VS2, VS1, v0.t ;                                          \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_WVV() runs a single vector instruction test.
@@ -355,7 +355,7 @@
     addi HELPER_GPR, DATA_BASE, DOFF ;                                  \
     VLE(SEW) VD, (HELPER_GPR) ;                                         \
     VINST VD, VS2, VS1 ;                                                \
-    RVTEST_SIGUPD_V(AVL, SEW, VD)                                       \
+    RVTEST_SIGUPD_V(SIG_BASE, HELPER_GPR, AVL, SEW, VD)                 \
 1:                                                                      \
 
 // TEST_CASE_BLOCK_64B_* macros contain 64 byte blocks of test data


### PR DESCRIPTION
Issue: vx instructions were not supported by test_macros_vectors.h because sigReg (SIG_BASE) was hard coded. This macro was designed to only support vv type instructions. When we want to use different integer registers, this may cause a conflict and causing tests to fail.

Solution:
Modified RVTEST_SIGUPD_V such that sigReg and tempReg can be passed in testgen.py and prevent conflicts. Tested on all vadd instructions and tests passed. Also update this change in arguments to the rest of this file to prevent failure in the original riscv-arch-test when pushed.
