### PR TITLE
Adding Signature logic for EndianM/S/U

### DIFF
--- a/riscv-test-suite/env/priv-endian.h
+++ b/riscv-test-suite/env/priv-endian.h
@@ -1,0 +1,282 @@
+///////////////////////////////////////////
+// priv-endian.h
+//
+// Written: mbellido@hmc.edu 18 february 2025
+// Adapted for to support both RV32 and RV64 mbellido@hmc.edu
+//
+// Purpose: has the fuctions to store and load for endianness
+// Feed in: provide the endianness for the reads the writes and the privilege
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// https://github.com/openhwgroup/cvw
+//
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// Registers used:
+//   s1: a 1 in bit specific to SBE or UBE to set/clear mstatus, mstatush or status
+//   s3: scratch address
+//   s4: endianness for write test
+//   s5: endianness for read test
+//   s6: return address for calls to endiantest
+//   s7: return address for calls to endianaccess
+//   s8: stored endianess value
+//   s9: return address for calls to setendianness
+//   s10: 0 to set/clear sstatus.UBE  (any other value otherwisse )
+//   s11: To switch back to running privilege mode once set/clear endianness
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Library used for EndianU, EndianM and EndianS
+// will store and load using the provided read and write endianness
+
+endiantest: //Write to memory function
+    # Try each size of stores with the write endianness, and then the loads with the read endianness
+    mv s8, s4       # setEndianness(write)
+    jal s9, setendianness
+    # Test storing bytes
+    li t0, 0x01
+    sb t0, 0(s3)
+    lb t3, 0(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x02
+    sb t0, 1(s3)
+    lb t3, 1(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x03
+    sb t0, 2(s3)
+    lb t3, 2(s3)          
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x04
+    sb t0, 3(s3)
+    lb t3, 3(s3)          
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x05
+    sb t0, 4(s3)
+    lb t3, 4(s3)         
+    RVTEST_SIGWRITE(x3, t3) 
+    li t0, 0x06
+    sb t0, 5(s3)
+    lb t3, 5(s3)          
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x07
+    sb t0, 6(s3)
+    lb t3, 6(s3)          
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x08
+    sb t0, 7(s3)
+    lb t3, 7(s3)     
+    RVTEST_SIGWRITE(x3, t3)
+    jal s7, endianaccess
+
+    mv s8, s4       # setEndianness(write)
+    jal s9, setendianness
+    li t0, 0x1112
+    sh t0, 0(s3)    
+    lh t3, 0(s3)     
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1314
+    sh t0, 2(s3)    
+    lh t3, 2(s3)     
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1516  
+    sh t0, 4(s3) 
+    lh t3, 4(s3)          
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1718
+    sh t0, 6(s3)  
+    lh t3, 6(s3)       
+    RVTEST_SIGWRITE(x3, t3)
+    jal s7, endianaccess
+
+    mv s8, s4       # setEndianness(write)
+    jal s9, setendianness
+    li t0, 0x21222324
+    sw t0, 0(s3)       
+    lw t3, 0(s3)  
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x25262728
+    sw t0, 4(s3)  
+    lw t3, 4(s3)          
+    RVTEST_SIGWRITE(x3, t3) 
+    jal s7, endianaccess
+
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            mv s8, s4       # setEndianness(write)
+            jal s9, setendianness
+            li t0, 0x3132333435363738
+            sd t0, 0(s3)  
+            ld t3, 0(s3)             
+            RVTEST_SIGWRITE(x3, t3)
+            jal s7, endianaccess
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+     # set up PMP so user and supervisor mode can access full address space
+
+    RVTEST_GOTO_MMODE   # set up everything in M-mode
+    jr s6   # return to endianM/S/U file (return address was stored in s6)
+
+
+
+
+
+setendianness:  //function to set/clear the bits depending on the endianness specified by the covergroups
+    RVTEST_GOTO_MMODE   # set up everything in M-mode    
+    beq s10, x0, onlysstatus3 //branch if endianness is given from sstatus (3 bc used by 3rd cp in endianS)
+    beqz s8, littleendian      # # if s8 = 1, bigendian, otherwise littleendian
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            csrrs t6, mstatus, s1   # for RV64, set mstatus
+            csrr  t4, mstatus        # get the *updated* value after setting
+            RVTEST_SIGWRITE(x3, t4)    
+        #elif __riscv_xlen == 32
+            csrrs t6, mstatush, s1  # for RV32, set mstatush
+            csrr t4, mstatush       # get the *updated* value after setting
+            RVTEST_SIGWRITE(x3, t4)   
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    j change
+
+    littleendian:
+        #ifdef __riscv_xlen
+            #if __riscv_xlen == 64
+                csrrc t6, mstatus, s1   # for RV64, clear mstatus            
+                csrr t4, mstatus        # get the *updated* value after setting
+                RVTEST_SIGWRITE(x3, t4) 
+            #elif __riscv_xlen == 32
+                csrrc t6, mstatush, s1  # for RV32, clear mstatush
+                csrr t4, mstatush       # get the *updated* value after setting
+                RVTEST_SIGWRITE(x3, t4) 
+            #endif
+        #else
+            ERROR: __riscv_xlen not defined
+        #endif
+        j change
+
+
+    onlysstatus3: //used for 3rd EndianS coverpoint: cp_sstatus_ube_endianness_* (endianness given in sstatus.UBE)
+        li a0, 1         # a0 = 1, change to supervisor mode ->to write to sstatus
+        RVTEST_GOTO_LOWER_MODE Smode 
+        nop
+        beqz s8, littleendian3      # little endian
+        csrrs t6, sstatus, s1   # set sstatus.UBE
+        nop
+        csrr t4, sstatus       # get the *updated* value after setting
+        RVTEST_SIGWRITE(x3, t4) 
+        j change
+
+        littleendian3:
+            csrrc t6, sstatus, s1   # clear sstatus.UBE
+            csrr t4, sstatus        # get the *updated* value after setting
+            RVTEST_SIGWRITE(x3, t4) 
+            j change
+
+    change: // Switch privilege mode
+        RVTEST_GOTO_MMODE   # set up everything in M-mode
+        li t2, 0
+        beq s11, t2, use_umode
+        li t2, 1
+        beq s11, t2, use_smode
+        li t2, 3
+        beq s11, t2, use_mmode
+
+        use_umode:
+            RVTEST_GOTO_LOWER_MODE Umode
+            RVTEST_SIGWRITE(x3, s11) 
+            jr s9
+        use_smode:
+            RVTEST_GOTO_LOWER_MODE Smode
+            RVTEST_SIGWRITE(x3, s11)
+            jr s9
+        use_mmode:
+            RVTEST_GOTO_MMODE
+            RVTEST_SIGWRITE(x3, s11) 
+            jr s9
+
+
+endianaccess:
+    // Try all the accesses to make sure they work for the endianness
+    mv s8, s5   # setEndianness(read)
+    jal s9, setendianness
+    lb  t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lb  t3, 1(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lb  t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lb  t3, 3(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lb  t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lb  t3, 5(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lb  t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lb  t3, 7(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 1(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 3(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 5(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lbu t3, 7(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lh  t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lh  t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lh  t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lh  t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lw t3, (s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lw t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            lwu  t3, 0(s3) # long loads for RV64
+            RVTEST_SIGWRITE(x3, t3) 
+            lwu  t3, 4(s3)
+            RVTEST_SIGWRITE(x3, t3) 
+            ld   t3, 0(s3)
+            RVTEST_SIGWRITE(x3, t3) 
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    jr s7   # return (return address was stored in s7)
+
+

--- a/riscv-test-suite/env/priv-endian.h
+++ b/riscv-test-suite/env/priv-endian.h
@@ -140,12 +140,12 @@ setendianness:  //function to set/clear the bits depending on the endianness spe
     #ifdef __riscv_xlen
         #if __riscv_xlen == 64
             csrrs t6, mstatus, s1   # for RV64, set mstatus
-            csrr  t4, mstatus        # get the *updated* value after setting
-            RVTEST_SIGWRITE(x3, t4)    
+            nop
+            RVTEST_SIGWRITE(x3, t6)    
         #elif __riscv_xlen == 32
             csrrs t6, mstatush, s1  # for RV32, set mstatush
-            csrr t4, mstatush       # get the *updated* value after setting
-            RVTEST_SIGWRITE(x3, t4)   
+            nop
+            RVTEST_SIGWRITE(x3, t6) 
         #endif
     #else
         ERROR: __riscv_xlen not defined
@@ -155,13 +155,13 @@ setendianness:  //function to set/clear the bits depending on the endianness spe
     littleendian:
         #ifdef __riscv_xlen
             #if __riscv_xlen == 64
-                csrrc t6, mstatus, s1   # for RV64, clear mstatus            
-                csrr t4, mstatus        # get the *updated* value after setting
-                RVTEST_SIGWRITE(x3, t4) 
+                csrrc t6, mstatus, s1   # for RV64, clear mstatus         
+                nop   
+                RVTEST_SIGWRITE(x3, t6) 
             #elif __riscv_xlen == 32
-                csrrc t6, mstatush, s1  # for RV32, clear mstatush
-                csrr t4, mstatush       # get the *updated* value after setting
-                RVTEST_SIGWRITE(x3, t4) 
+                csrrc t6, mstatush, s1  # for RV32, clear CSR_MSTATUSH
+                nop
+                RVTEST_SIGWRITE(x3, t6) 
             #endif
         #else
             ERROR: __riscv_xlen not defined
@@ -172,18 +172,20 @@ setendianness:  //function to set/clear the bits depending on the endianness spe
     onlysstatus3: //used for 3rd EndianS coverpoint: cp_sstatus_ube_endianness_* (endianness given in sstatus.UBE)
         li a0, 1         # a0 = 1, change to supervisor mode ->to write to sstatus
         RVTEST_GOTO_LOWER_MODE Smode 
-        nop
         beqz s8, littleendian3      # little endian
         csrrs t6, sstatus, s1   # set sstatus.UBE
         nop
         csrr t4, sstatus       # get the *updated* value after setting
+        nop
         RVTEST_SIGWRITE(x3, t4) 
+        RVTEST_SIGWRITE(x3, t6) 
         j change
 
         littleendian3:
             csrrc t6, sstatus, s1   # clear sstatus.UBE
             csrr t4, sstatus        # get the *updated* value after setting
             RVTEST_SIGWRITE(x3, t4) 
+            RVTEST_SIGWRITE(x3, t6) 
             j change
 
     change: // Switch privilege mode

--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -576,7 +576,24 @@ Mend_PMP:                                    ;\
       SREG _F,offset(_BR)					;\
       .set offset,offset+(REGWIDTH)
 
-
+ /* Stores register into signature region and increment the signature pointer */
+ /* RVTEST_SIGUPD does not properly handle code that jumps over macros due to garbling the offset.*/
+ /* Do not mix RVTEST_SIGWRITE and RVTEST_SIGUPD in the same program */
+ /* RVTEST_SIGWRITE(basereg, sigreg) stores sigreg at 0(basereg) and increments basereg by regwidth	 */
+ #define RVTEST_SIGWRITE(_BR,_R)            ;\
+      SREG _R, 0(_BR)					;\
+      addi _BR, _BR, REGWIDTH 
+  
+ /* Stores register into signature region and increment the signature pointer*/
+ /* RVTEST_SIGUPD_F does not properly handle code that jumps over macros due to garbling the offset.*/
+ /* Do not mix RVTEST_SIGWRITE_F and RVTEST_SIGUPD_F in the same program */
+ /* RVTEST_SIGWRITE_F(basereg, sigreg, flagreg) stores sigreg at 0(basereg) and increments basereg by sigalign	 */
+ /* SIGALIGN is set to the max(FREGWIDTH, REGWIDTH)*/
+#define RVTEST_SIGWRITE_F(_BR,_R,_f)        ;\
+      FSREG _R, 0(_BR)					;\
+      SREG _F, SIGALIGN(_BR)					;\
+      addi _BR, _BR, 2*SIGALIGN
+      
 
   /* DEPRECATE this is redundant with RVTEST_BASEUPD(BR,_NR),	*/
   /* except it doesn't correct for offset overflow while moving */
@@ -599,9 +616,9 @@ Mend_PMP:                                    ;\
 
 #define RVTEST_BASEUPD(_BR,...)				;\
  /* deal with case where offset>=2047 */		;\
-       .set corr 2048-REGWIDTH				;\
+        .set corr, 2048-REGWIDTH				;\
     .if offset <2048 					;\
-       .set corr offset					;\
+       .set corr, offset					;\
     .endif						;\
     .set offset, offset-corr				;\
 							;\

--- a/riscv-test-suite/privileged/EndianM.S
+++ b/riscv-test-suite/privileged/EndianM.S
@@ -1,0 +1,175 @@
+///////////////////////////////////////////
+// EndianM.S
+//
+// Written: David_Harris@hmc.edu 19 November 2024
+//
+// Purpose: Functional coverage tests for endianness in machine mode
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+///////////////////////////////////////////
+
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV32I_Zicsr, RV64I_Zicsr")
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def rvtest_dtrap_routine=True; def TEST_CASE_1=True",EndianM)
+
+RVTEST_SIGBASE( x3,signature_base)
+
+	.attribute unaligned_access, 0
+	.attribute stack_align, 16
+  	.align	2   
+  	.option norvc
+    
+main:
+/////////////////////////////////
+// Endianness testing
+// cp_mstatush_mbe_endianness
+// cp_mstatus_mbe_endianness
+//
+// Goal is to store a pattern to a scratch location in memory
+// using each endianness, and stores of every size.  Then
+// read back the value using each endianness and loads of
+// every size.  Stress that endianness works for every access.
+//
+// Saving and restoring from the stack is tricky because the
+// code must work for both RV32 and RV64, and the endianness
+// is constantly changing.  Therefore, we use s6 and s7 (found in priv-endian.h)for
+// return addresses instead.
+//
+// Registers used:
+//   s0: saved value of mstatus
+//   s1: a 1 in bit 5 to set/clear mstatush.MBE (RV32) or bit 37 to set/clear mstatus.MBE (RV64)
+//   s3: scratch address
+//   s4: endianness for write test
+//   s5: endianness for read test
+//   s10: 0 to set/clear sstatus.UBE  (any other value otherwisse )
+//   s11: To switch back to running privilege mode once set/clear endianness
+//   t5: signature pointer
+//   x3: pointer to signature base
+///////////////////////////////////////////////
+    // save mstatus
+    // prep s1 with bits to set/clear MBE for RV32/RV64
+    // always do both.  One or the other will trap, but this
+    // avoids needing separate code for the two architectures
+    // code assumes s registers are saved during these tests
+    // saving and restoring mstatus based on endianness
+    // calling WALLY-priv-endian.h to store and load
+
+    csrr s0, mstatus    # save CSR
+    //mv t5, x3  # 
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            li s1, 0x2000000000     # 1 in bit 37 for mstatus.MBE
+        #elif __riscv_xlen == 32
+            li s1, 0x20             # 1 in bit 5 for mstatush.MBE
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    la s3, scratch  # s3 = pointer to scratch
+    li s10, 1
+    li s11, 3       # passing privilige mode: machine
+    RVTEST_SIGWRITE(x3,s11)
+
+    // iterate over each endianness, doing all sizes of stores and loads
+    li s4, 0        # endianness for write
+    RVTEST_SIGWRITE(x3, s4)
+    li s5, 0        # endianness for read
+    RVTEST_SIGWRITE(x3, s5)
+    jal s6, endiantest  # test little-endian read and write
+
+    li s4, 1        # endianness for write
+    RVTEST_SIGWRITE(x3, s4)
+    jal s6, endiantest  # test big-endian write, little-endian read
+
+    li s5, 1        # endianness for read
+    RVTEST_SIGWRITE(x3, s5)
+    jal s6, endiantest  # test big-endian read and write
+
+    li s4, 0        # endianness for write
+    RVTEST_SIGWRITE(x3, s4)
+    jal s6, endiantest  # test little-endian write, big-endian read
+
+    post_cp_mstatus_mbe_endianness:
+        csrrw t6, mstatus, s0    # restore CSR
+        jal s6, test_end
+
+
+#include "priv-endian.h" 
+
+test_end: //finish
+
+
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+    # HALT
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+# Allocate scratch memory in .bss section
+.section .bss
+.align 4
+scratch:
+    .space 136  # Reserve 136 bytes of uninitialized memory
+
+# scratch:
+# .fill 4,4,0x0
+# # Initialize stack with room for 512 bytes
+# .bss
+#     .space 512
+# topofstack:
+
+RVTEST_DATA_BEGIN
+# Input data section.
+.data
+.align 4
+rvtest_data:
+.word 0xb0bacafe
+.word 0xb0bacafe
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+signature_base:
+    .fill 600*(XLEN/32),4,0xdeadbeef
+    
+# test_A_res:
+#     .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 15*(XLEN/32),4,0xb0bacafe
+#Prof Harris mentioned we should probably start with 10000
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+

--- a/riscv-test-suite/privileged/EndianS.S
+++ b/riscv-test-suite/privileged/EndianS.S
@@ -1,0 +1,1187 @@
+///////////////////////////////////////////
+// EndianS.S
+//
+// Written: mbellido@hmc.edu 1 February 2025
+//
+// Purpose: Functional coverage tests for endianness in supervisor mode
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+///////////////////////////////////////////
+
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV32I_Zicsr, RV64I_Zicsr")
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def rvtest_dtrap_routine=True; def TEST_CASE_1=True",EndianS)
+RVTEST_SIGBASE( x3,signature_base)
+
+	.attribute unaligned_access, 0
+	.attribute stack_align, 16
+  	.align	2   
+  	.option norvc
+    
+main:
+
+ # set up PMP so user and supervisor mode can access full address space
+    csrw pmpcfg0, 0xF   # configure PMP0 to TOR RWX
+    li t0, 0xFFFFFFFF
+    csrw pmpaddr0, t0   # configure PMP0 top of range to 0xFFFFFFFF to allow all 32-bit addresses
+    csrw satp, x0       # turn off satp to disable VM 
+
+/////////////////////////////////
+// Endianness testing
+// cp_mstatus_sbe_endianness_*
+// cp_mstatus_mprv_sbe_endianness_*
+// cp_sstatus_ube_endianness_*
+//
+// Goal is to store a pattern to a scratch location in memory
+// using each endianness, and stores of every size.  Then
+// read back the value using each endianness and loads of
+// every size.  Stress that endianness works for every access.
+//
+// Saving and restoring from the stack is tricky because the
+// code must work for both RV32 and RV64, and the endianness
+// is constantly changing.  Therefore, we use s6 and s7 for
+// return addresses instead.
+//
+// Registers used:
+//   s0: saved value of mstatus
+//   s1: a 1 in bit specific to SBE or UBE to set/clear mstatus, mstatush or status
+//   s3: scratch address
+//   s4: endianness for write test
+//   s5: endianness for read test
+//   s6: return address for calls to endiantest
+//   s7: return address for calls to endianaccess
+//   s10: 0 to set/clear sstatus.UBE  (any other value otherwisse )
+//   s11: To switch back to running privilege mode once set/clear endianness
+
+/////////////////////////////////
+
+  // 1ST COVERPOINT:  cp_mstatus_sbe_endianness_*
+    // save mstatus
+    // ecall to move to supervisor mode: use macro RVTEST_GOTO_LOWER_MODE Smode
+    // prep s1 with bits to set/clear SBE for RV32/RV64
+    // always do both.  One or the other will trap, but this
+    // avoids needing separate code for the two architectures
+    // code assumes s registers are saved during these tests
+    // saving and restoring mstatus based on endianness
+    // calling WALLY-priv-endian.h to store and load
+
+    csrr s0, mstatus    # save CSR
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            li s1, 0x1000000000       # 1 in bit 36 for mstatus.SBE
+        #elif __riscv_xlen == 32
+            li s1, 0x10               # 1 in bit 4 for mstatush.SBE
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    la s3, scratch                    # s3 = pointer to scratch
+    // s10, s11 used in WALLY-priv-endian.h
+    li s10, 1  # setendianess function: 1 to stay in func since running mstatus
+    li s11, 1  # resetting privilige after accessing mstatush
+    RVTEST_SIGWRITE(x3,s11)
+
+    // Iterate over each endianness, doing all sizes of stores and loads
+    li  s4, 0           # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    li  s5, 0           # endianness for read
+    RVTEST_SIGWRITE(x3,s5)
+    jal s6, endiantest  # test little-endian read and write
+
+    li  s4, 1           # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    jal s6, endiantest  # test big-endian write, little-endian read
+
+    li  s5, 1           # endianness for read
+    RVTEST_SIGWRITE(x3,s5)
+    jal s6, endiantest  # test big-endian read and write
+
+    li  s4, 0           # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    jal s6, endiantest  # test little-endian write, big-endian read
+
+post_cp_mstatus_sbe_endianness:
+    csrrw t6, mstatus, s0    # restore CSR
+
+    # To seperate Coverpoint signatures
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+ 
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// 2ND COVERPOINT:  cp_mstatus_mprv_sbe_endianness_*
+//////////////////////////////////////////////////////////////////////////////////////////
+    // save mstatus
+    // ecall to move to supervisor mode: use macro RVTEST_GOTO_LOWER_MODE Smode
+    // Setting 16 cases for MPRV, MPP, SBE and MBE
+    // 1st 16 cases are write and the  2nd 16 cases are read
+    // ---------------------------------------
+    //     XLEN=64        |     XLEN=32
+    // --------------------------------------
+    //  MBE  0x2000000000 | 0x20
+    //  SBE  0x1000000000 | 0x10
+    //  MPRV 0x20000      | 0x20000
+    //  MPP  0x1800       | 0x1800
+    // --------------------------------------
+    // bit 17 for mstatus.MPRV
+    // bit 12 for mstatus.MPP
+    // bit 11 for mstatus.MPP
+    // MBE AND SBE:
+    //   64 bits: use mstatus
+    //         bit 37 for mstatus.MBE
+    //         bit 36 for mstatus.SBE
+    //   32 bits: use mstatush
+    //         bit 5 for mstatush.MBE
+    //         bit 4 for mstatush.SBE
+
+    csrr s0, mstatus    # save CSR
+    RVTEST_GOTO_MMODE   # set up everything in M-mode
+    la s3, scratch  # s3 = pointer to scratch
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+        // 16 WRITES:
+            // 1:  MPRV=0, MPP=01, MBE=0, SBE=0
+            li      t3,   0x3000021000    # 0s
+            li      t4,   0x800           # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2 #storing address so when you jump you can come back when done
+            // 2:  MPRV=0, MPP=01, MBE=0, SBE=1
+            li      t3,   0x2000021000    # 0s
+            li      t4,   0x1000000800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 3:  MPRV=0, MPP=01, MBE=1, SBE=0
+            li      t3,   0x1000021000    # 0s
+            li      t4,   0x2000000800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 4:  MPRV=0, MPP=01, MBE=1, SBE=1
+            li      t3,   0x21000         # 0s
+            li      t4,   0x3000000800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 5:  MPRV=0, MPP=11, MBE=0, SBE=0
+            li      t3,   0x3000020000    # 0s
+            li      t4,   0x1800          # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 6:  MPRV=0, MPP=11, MBE=0, SBE=1
+            li      t3,   0x2000020000    # 0s
+            li      t4,   0x1000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 7:  MPRV=0, MPP=11, MBE=1, SBE=0
+            li      t3,   0x1000020000    # 0s
+            li      t4,   0x2000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 8:  MPRV=0, MPP=11, MBE=1, SBE=1
+            li      t3,   0x20000         # 0s
+            li      t4,   0x3000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 9:  MPRV=1, MPP=01, MBE=0, SBE=0
+            li      t3,   0x3000001000    # 0s
+            li      t4,   0x20800         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 10: MPRV=1, MPP=01, MBE=0, SBE=1
+            li      t3,   0x2000001000    # 0s
+            li      t4,   0x1000020800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 11: MPRV=1, MPP=01, MBE=1, SBE=0
+            li      t3,   0x1000001000    # 0s
+            li      t4,   0x2000020800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 12: MPRV=1, MPP=01, MBE=1, SBE=1
+            li      t3,   0x1000          # 0s
+            li      t4,   0x3000020800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 13: MPRV=1, MPP=11, MBE=0, SBE=0
+            li      t3,   0x3000000000    # 0s
+            li      t4,   0x21800         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 14: MPRV=1, MPP=11, MBE=0, SBE=1
+            li      t3,   0x2000000000    # 0s
+            li      t4,   0x1000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 15: MPRV=1, MPP=11, MBE=1, SBE=0
+            li      t3,   0x1000000000    # 0s
+            li      t4,   0x2000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 16: MPRV=1, MPP=11, MBE=1, SBE=1
+            li      t3,   0x0             # 0s
+            li      t4,   0x3000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+
+        // 16 READS:
+            // 1:  MPRV=0, MPP=01, MBE=0, SBE=0
+            li      t3,   0x3000021000    # 0s
+            li      t4,   0x800           # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 2:  MPRV=0, MPP=01, MBE=0, SBE=1
+            li      t3,   0x2000021000    # 0s
+            li      t4,   0x1000000800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 3:  MPRV=0, MPP=01, MBE=1, SBE=0
+            li      t3,   0x1000021000    # 0s
+            li      t4,   0x2000000800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 4:  MPRV=0, MPP=01, MBE=1, SBE=1
+            li      t3,   0x21000         # 0s
+            li      t4,   0x3000000800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 5:  MPRV=0, MPP=11, MBE=0, SBE=0
+            li      t3,   0x3000020000    # 0s
+            li      t4,   0x1800          # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 6:  MPRV=0, MPP=11, MBE=0, SBE=1
+            li      t3,   0x2000020000    # 0s
+            li      t4,   0x1000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 7:  MPRV=0, MPP=11, MBE=1, SBE=0
+            li      t3,   0x1000020000    # 0s
+            li      t4,   0x2000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 8:  MPRV=0, MPP=11, MBE=1, SBE=1
+            li      t3,   0x20000         # 0s
+            li      t4,   0x3000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 9:  MPRV=1, MPP=01, MBE=0, SBE=0
+            li      t3,   0x3000001000    # 0s
+            li      t4,   0x20800         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 10: MPRV=1, MPP=01, MBE=0, SBE=1
+            li      t3,   0x2000001000    # 0s
+            li      t4,   0x1000020800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 11: MPRV=1, MPP=01, MBE=1, SBE=0
+            li      t3,   0x1000001000    # 0s
+            li      t4,   0x2000020800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 12: MPRV=1, MPP=01, MBE=1, SBE=1
+            li      t3,   0x1000          # 0s
+            li      t4,   0x3000020800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 13: MPRV=1, MPP=11, MBE=0, SBE=0
+            li      t3,   0x3000000000    # 0s
+            li      t4,   0x21800         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 14: MPRV=1, MPP=11, MBE=0, SBE=1
+            li      t3,   0x2000000000    # 0s
+            li      t4,   0x1000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 15: MPRV=1, MPP=11, MBE=1, SBE=0
+            li      t3,   0x1000000000    # 0s
+            li      t4,   0x2000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 16: MPRV=1, MPP=11, MBE=1, SBE=1
+            li      t3,   0x0             # 0s
+            li      t4,   0x3000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            //jal s8, post_cp_mstatus_mprv_sbe_endianness
+            j post_cp_mstatus_mprv_sbe_endianness
+
+
+
+        #elif __riscv_xlen == 32
+        csrr s1, mstatush
+        // 16 WRITES:
+            // 1:  MPRV=0, MPP=01, MBE=0, SBE=0
+            li      t3, 0x21000       # 0s -> mstatus
+            li      t4, 0x800         # 1s -> mstatus
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x00          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 2:  MPRV=0, MPP=01, MBE=0, SBE=1
+            li      t3, 0x21000       # 0s
+            li      t4, 0x800         # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 3:  MPRV=0, MPP=01, MBE=1, SBE=0
+            li      t3, 0x21000       # 0s
+            li      t4, 0x800         # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 4:  MPRV=0, MPP=01, MBE=1, SBE=1
+            li      t3, 0x21000       # 0s
+            li      t4, 0x800         # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 5:  MPRV=0, MPP=11, MBE=0, SBE=0
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 6:  MPRV=0, MPP=11, MBE=0, SBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 7:  MPRV=0, MPP=11, MBE=1, SBE=0
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 8:  MPRV=0, MPP=11, MBE=1, SBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 9:  MPRV=1, MPP=01, MBE=0, SBE=0
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 10: MPRV=1, MPP=01, MBE=0, SBE=1
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 11: MPRV=1, MPP=01, MBE=1, SBE=0
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 12: MPRV=1, MPP=01, MBE=1, SBE=1
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 13: MPRV=1, MPP=11, MBE=0, SBE=0
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 14: MPRV=1, MPP=11, MBE=0, SBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 15: MPRV=1, MPP=11, MBE=1, SBE=0
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 16: MPRV=1, MPP=11, MBE=1, SBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+
+        // 16 READS:
+            // 1:  MPRV=0, MPP=01, MBE=0, SBE=0
+            li      t3, 0x21000       # 0s -> mstatus
+            li      t4, 0x800         # 1s -> mstatus
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x00          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 2:  MPRV=0, MPP=01, MBE=0, SBE=1
+            li      t3, 0x21000       # 0s
+            li      t4, 0x800         # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 3:  MPRV=0, MPP=01, MBE=1, SBE=0
+            li      t3, 0x21000       # 0s
+            li      t4, 0x800         # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 4:  MPRV=0, MPP=01, MBE=1, SBE=1
+            li      t3, 0x21000       # 0s
+            li      t4, 0x800         # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 5:  MPRV=0, MPP=11, MBE=0, SBE=0
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 6:  MPRV=0, MPP=11, MBE=0, SBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 7:  MPRV=0, MPP=11, MBE=1, SBE=0
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 8:  MPRV=0, MPP=11, MBE=1, SBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 9:  MPRV=1, MPP=01, MBE=0, SBE=0
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 10: MPRV=1, MPP=01, MBE=0, SBE=1
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 11: MPRV=1, MPP=01, MBE=1, SBE=0
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 12: MPRV=1, MPP=01, MBE=1, SBE=1
+            li      t3, 0x1000        # 0s
+            li      t4, 0x20800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 13: MPRV=1, MPP=11, MBE=0, SBE=0
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x30          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 14: MPRV=1, MPP=11, MBE=0, SBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x10          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 15: MPRV=1, MPP=11, MBE=1, SBE=0
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x10          # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 16: MPRV=1, MPP=11, MBE=1, SBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x30          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            j post_cp_mstatus_mprv_sbe_endianness
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+
+
+
+endianwrite2:
+    //  Try each size of stores with the write endianness
+    //  Test storing bytes
+    li t0, 0x01
+    sb t0, 0(s3)
+    lb t3, 0(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x02
+    sb t0, 1(s3)
+    lb t3, 1(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x03
+    sb t0, 2(s3)
+    lb t3, 2(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x04
+    sb t0, 3(s3)
+    lb t3, 3(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x05
+    sb t0, 4(s3)
+    lb t3, 4(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x06
+    sb t0, 5(s3)
+    lb t3, 5(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x07
+    sb t0, 6(s3)
+    lb t3, 6(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x08
+    sb t0, 7(s3)
+    lb t3, 7(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1112
+    sh t0, 0(s3)
+    lh t3, 0(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1314
+    sh t0, 2(s3)
+    lh t3, 2(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1516
+    sh t0, 4(s3)
+    lh t3, 4(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1718
+    sh t0, 6(s3)
+    lh t3, 6(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x21222324
+    sw t0, 0(s3)
+    lw t3, 0(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x25262728
+    sw t0, 4(s3)
+    lw t3, 4(s3)         
+    RVTEST_SIGWRITE(x3, t3)
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            li t0, 0x3132333435363738
+            sd t0, 0(s3)            # sd only in RV64
+            ld t3, 0(s3)         
+            RVTEST_SIGWRITE(x3, t3)
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    jr s6   # return (return address was stored in s6)
+
+
+endianread2:
+    // loads with the read endianness
+    // Try all the accesses to make sure they work for the endianness
+    li  t0, 0x01
+    sb  t0, 0(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    li  t0, 0x02
+    sb  t0, 1(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    li  t0, 0x03
+    sb  t0, 2(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    li  t0, 0x04
+    sb  t0, 3(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    li  t0, 0x05
+    sb  t0, 4(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    li  t0, 0x06
+    sb  t0, 5(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    li  t0, 0x07
+    sb  t0, 6(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    li  t0, 0x08
+    sb  t0, 7(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 0(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 1(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 2(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 3(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 4(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 5(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 6(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lb  t0, 7(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 0(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 1(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 2(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 3(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 4(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 5(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 6(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lbu t0, 7(s3)
+    RVTEST_SIGWRITE(x3, t0) 
+    lh  t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lh  t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lh  t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lh  t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lhu t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lw  t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    lw  t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3) 
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            lwu t3, 0(s3) # long loads for RV64
+            RVTEST_SIGWRITE(x3, t3) 
+            lwu t3, 4(s3)
+            RVTEST_SIGWRITE(x3, t3) 
+            ld  t3, 0(s3)
+            RVTEST_SIGWRITE(x3, t3) 
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    jr s7   # return (return address was stored in s7)
+
+
+
+    post_cp_mstatus_mprv_sbe_endianness:
+        csrrw t6, mstatus, s0    # restore CSR
+        // restoring mstatush if rv32
+        #ifdef __riscv_xlen
+            #if __riscv_xlen == 32
+                csrrw t5, mstatush, s1
+            #endif
+        #else
+            ERROR: __riscv_xlen not defined
+        #endif
+        //jr s8
+
+
+
+
+    # To seperate Coverpoint signatures
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+ 
+
+
+///////////////////////////////////////////////////////////////////
+//  3RD COVERPOINT: cp_sstatus_ube_endianness_*
+///////////////////////////////////////////////////////////////////
+    // Runs tests in user mode and endianness given in sstatus.UBE
+    // save sstatus
+    // ecall to move to user mode: use macro RVTEST_GOTO_LOWER_MODE Umode
+    // prep s1 with bits to set/clear UBE
+    // code assumes s registers are saved during these tests
+    // saving and restoring mstatus based on endianness
+    // calling WALLY-priv-endian.h to store and load
+    csrr s0, sstatus      # save CSR
+    RVTEST_GOTO_LOWER_MODE Umode
+    #ifdef __riscv_xlen
+        li s1, 0x40       # 1 in bit 6 for sstatus.UBE
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    la s3, scratch  # s3 = pointer to scratch
+    // s10 used in WALLY-priv-endian.h
+    li s10, 0   # setendianess function: 0 to branch to status
+    li s11, 0   # switching back to user mode in lybrary function
+    RVTEST_SIGWRITE(x3,s11)
+
+    // iterate over each endianness, doing all sizes of stores and loads
+    li  s4, 0           # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    li  s5, 0           # endianness for read
+    RVTEST_SIGWRITE(x3,s5)
+    jal s6, endiantest  # test little-endian read and write
+
+    li  s4, 1           # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    jal s6, endiantest  # test big-endian write, little-endian read
+
+    li  s5, 1           # endianness for read
+    RVTEST_SIGWRITE(x3,s5)
+    jal s6, endiantest  # test big-endian read and write
+
+    li  s4, 0           # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    jal s6, endiantest  # test little-endian write, big-endian read
+
+post_cp_sstatus_ube_endianness:
+    csrrw t6, sstatus, s0    # restore CSR
+    jal s6, test_end
+
+
+#include "priv-endian.h"
+
+test_end: //finish
+
+
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+    # HALT
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+# Allocate scratch memory in .bss section
+.section .bss
+.align 4
+scratch:
+    .space 136  # Reserve 136 bytes of uninitialized memory
+
+
+RVTEST_DATA_BEGIN
+# Input data section.
+.data
+.align 4
+rvtest_data:
+.word 0xb0bacafe
+.word 0xb0bacafe
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+signature_base:
+    .fill 2250*(XLEN/32),4,0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+.fill 150*(XLEN/32),4,0xb0bacafe
+strap_sigptr:
+.fill 150*(XLEN/32),4,0xdeadbeef
+utrap_sigptr:
+.fill 150*(XLEN/32),4,0xb0bacafe
+#Prof Harris mentioned we should probably start with 10000
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+
+

--- a/riscv-test-suite/privileged/EndianS.S
+++ b/riscv-test-suite/privileged/EndianS.S
@@ -1162,10 +1162,7 @@ tsig_begin_canary:
 CANARY;
 mtrap_sigptr:
 .fill 150*(XLEN/32),4,0xb0bacafe
-strap_sigptr:
-.fill 150*(XLEN/32),4,0xdeadbeef
-utrap_sigptr:
-.fill 150*(XLEN/32),4,0xb0bacafe
+
 #Prof Harris mentioned we should probably start with 10000
 tsig_end_canary:
 CANARY;

--- a/riscv-test-suite/privileged/EndianU.S
+++ b/riscv-test-suite/privileged/EndianU.S
@@ -1043,9 +1043,7 @@ postendian2:
     #else
         ERROR: __riscv_xlen not defined
     #endif
-
-
-jal s6, test_end
+    jal s6, test_end
 
 #include "priv-endian.h"
 test_end: //finish
@@ -1092,6 +1090,10 @@ tsig_begin_canary:
 CANARY;
 mtrap_sigptr:
     .fill 200*(XLEN/32),4,0xb0bacafe
+# strap_sigptr:
+# .fill 150*(XLEN/32),4,0xdeadbeef
+# utrap_sigptr:
+# .fill 150*(XLEN/32),4,0xb0bacafe
 tsig_end_canary:
 CANARY;
 

--- a/riscv-test-suite/privileged/EndianU.S
+++ b/riscv-test-suite/privileged/EndianU.S
@@ -1,0 +1,1111 @@
+///////////////////////////////////////////
+// EndianU.S
+//
+// Written: mbellido@hmc.edu 9 February 2025
+//
+// Purpose: Functional coverage tests for endianness in user mode
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+///////////////////////////////////////////
+
+
+
+#include "model_test.h"
+#include "arch_test.h"
+RVTEST_ISA("RV32I_Zicsr, RV64I_Zicsr")
+# Test code region
+.section .text.init
+.globl rvtest_entry_point
+rvtest_entry_point:
+RVMODEL_BOOT
+RVTEST_CODE_BEGIN
+
+#ifdef TEST_CASE_1
+    RVTEST_CASE(1,"//check ISA:=regex(.*I.*Zicsr.*); def rvtest_mtrap_routine=True; def rvtest_strap_routine=True; def rvtest_dtrap_routine=True; def TEST_CASE_1=True",EndianU)
+
+RVTEST_SIGBASE( x3,signature_base)
+
+	.attribute unaligned_access, 0
+	.attribute stack_align, 16
+  	.align	2   
+  	.option norvc
+
+main:
+
+ # set up PMP so user and supervisor mode can access full address space
+    csrw pmpcfg0, 0xF   # configure PMP0 to TOR RWX
+    li t0, 0xFFFFFFFF
+    csrw pmpaddr0, t0   # configure PMP0 top of range to 0xFFFFFFFF to allow all 32-bit addresses
+    csrw satp, x0       # turn off satp to disable VM 
+
+/////////////////////////////////
+// Endianness testing
+// cp_mstatus_ube_endianness_*
+// cp_mstatus_mprv_ube_endianness isn’t implemented yet.
+//
+// Goal is to store a pattern to a scratch location in memory
+// using each endianness, and stores of every size.  Then
+// read back the value using each endianness and loads of
+// every size.  Stress that endianness works for every access.
+//
+// Saving and restoring from the stack is tricky because the
+// code must work for both RV32 and RV64, and the endianness
+// is constantly changing.  Therefore, we use s6 and s7 for
+// return addresses instead.
+//
+// Registers used:
+//   s0: saved value of mstatus
+//   s1: a 1 in bit 5 to set/clear mstatush.UBE (RV32) or bit 37 to set/clear mstatus.UBE (RV64)
+//   s3: scratch address
+//   s4: endianness for write test
+//   s5: endianness for read test
+//   s6: return address for calls to endiantest
+//   s7: return address for calls to endianaccess
+//   s10: 0 to set/clear sstatus.UBE  (any other value otherwisse )
+//   s11: To switch back to running privilege mode once set/clear endianness
+/////////////////////////////////
+    // 1ST COVERPOINT:  cp_mstatus_ube_endianness_*!!!
+    // save mstatus
+    // prep s1 and s2 with bits to set/clear SBE for RV32/RV64
+    // always do both.  One or the other will trap, but this
+    // avoids needing separate code for the two architectures
+    // code assumes s registers are saved during these tests
+    // saving and restoring mstatus based on endianness
+
+    csrr s0, mstatus     # save CSR
+    #ifdef __riscv_xlen
+            li s1, 0x40  # 1 in bit 6 for mstatus.UBE
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    la s3, scratch       # s3 = pointer to scratch
+    // s10, s11 used in WALLY-priv-endian.h
+    li s10, 1   # setendianess function: aready branch in s9, but 1 just in case
+    li s11, 0   #resseting user mode
+    RVTEST_SIGWRITE(x3,s11)
+
+    // iterate over each endianness, doing all sizes of stores and loads
+    li s4, 0        # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    li s5, 0        # endianness for read
+    RVTEST_SIGWRITE(x3,s5)
+    jal s6, endiantest  # test little-endian read and write
+
+    li s4, 1        # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    jal s6, endiantest  # test big-endian write, little-endian read
+
+    li s5, 1        # endianness for read
+    RVTEST_SIGWRITE(x3,s5)
+    jal s6, endiantest  # test big-endian read and write
+
+    li s4, 0        # endianness for write
+    RVTEST_SIGWRITE(x3,s4)
+    
+    jal s6, endiantest  # test little-endian write, big-endian read
+
+post_cp_mstatus_ube_endianness:
+    csrrw t6, mstatus, s0    # restore CSR
+
+
+
+    # To seperate Coverpoint signatures
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+    li  t0, -1
+    RVTEST_SIGWRITE(x3, t0)  # write -1 to x3 to indicate start of test
+ 
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// 2ND COVERPOINT:  cp_mstatus_mprv_sbe_endianness_*
+//////////////////////////////////////////////////////////////////////////////////////////
+    // save mstatus
+    // ecall to move to supervisor mode use macro: RVTEST_GOTO_LOWER_MODE Smode
+    // Setting 16 cases for MPRV, MPP, SBE and MBE
+    // 1st 16 cases are write and the  2nd 16 cases are read
+    // ---------------------------------------
+    //    XLEN=64        |     XLEN=32
+    // --------------------------------------
+    //  MBE  0x2000000000 | 0x20
+    // MPRV 0x20000      | 0x20000
+    //  MPP  0x1800       | 0x1800
+    //  UBE  0X40         | 0X40
+    // --------------------------------------
+    // bit 17 for mstatus.MPRV
+    // bit 12 for mstatus.MPP
+    // bit 11 for mstatus.MPP
+    // bit 6 for  mstatus.UBE
+    // MBE AND SBE:
+    //   64 bits: use mstatus
+    //        bit 37 for mstatus.MBE
+    //   32 bits: use mstatush
+    //        bit 5 for mstatush.MBE
+    csrr s0, mstatus    # save CSR
+    RVTEST_GOTO_MMODE   # set up everything in M-mode
+    la s3, scratch      # s3 = pointer to scratch
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+        // 16 WRITES:
+            // 1:  MPRV=0, MPP=00, MBE=0, UBE=0
+            li      t3,   0x2000021840    # 0s
+            li      t4,   0x0             # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2          #storing address so when you jump you can come back when done
+            // 2:  MPRV=0, MPP=00, MBE=0, UBE=1
+            li      t3,   0x2000021800    # 0s
+            li      t4,   0x40            # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 3:  MPRV=0, MPP=00, MBE=1, UBE=0
+            li      t3,   0x21840         # 0s
+            li      t4,   0x2000000000    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 4:  MPRV=0, MPP=00, MBE=1, UBE=1
+            li      t3,   0x21800         # 0s
+            li      t4,   0x2000000040    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 5:  MPRV=0, MPP=11, MBE=0, UBE=0
+            li      t3,   0x2000020040    # 0s
+            li      t4,   0x1800          # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 6:  MPRV=0, MPP=11, MBE=0, UBE=1
+            li      t3,   0x2000020000    # 0s
+            li      t4,   0x1840          # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 7:  MPRV=0, MPP=11, MBE=1, UBE=0
+            li      t3,   0x20040         # 0s
+            li      t4,   0x2000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 8:  MPRV=0, MPP=11, MBE=1, UBE=1
+            li      t3,   0x20000         # 0s
+            li      t4,   0x2000001840    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 9:  MPRV=1, MPP=00, MBE=0, UBE=0
+            li      t3,   0x2000001840    # 0s
+            li      t4,   0x20000         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 10: MPRV=1, MPP=00, MBE=0, UBE=1
+            li      t3,   0x2000001800    # 0s
+            li      t4,   0x20040         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 11: MPRV=1, MPP=00, MBE=1, UBE=0
+            li      t3,   0x1840          # 0s
+            li      t4,   0x2000020000    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 12: MPRV=1, MPP=00, MBE=1, UBE=1
+            li      t3,   0x1800          # 0s
+            li      t4,   0x2000020040    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 13: MPRV=1, MPP=11, MBE=0, UBE=0
+            li      t3,   0x2000000040    # 0s
+            li      t4,   0x21800         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 14: MPRV=1, MPP=11, MBE=0, UBE=1
+            li      t3,   0x2000000000    # 0s
+            li      t4,   0x21840         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 15: MPRV=1, MPP=11, MBE=1, UBE=0
+            li      t3,   0x40            # 0s
+            li      t4,   0x2000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+            // 16: MPRV=1, MPP=11, MBE=1, UBE=1
+            li      t3,   0x0             # 0s
+            li      t4,   0x2000021840    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s6, endianwrite2
+        // 16 READS:
+            // 1:  MPRV=0, MPP=00, MBE=0, UBE=0
+            li      t3,   0x2000021840    # 0s
+            li      t4,   0x0             # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 2:  MPRV=0, MPP=00, MBE=0, UBE=1
+            li      t3,   0x2000021800    # 0s
+            li      t4,   0x40            # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 3:  MPRV=0, MPP=00, MBE=1, UBE=0
+            li      t3,   0x21840         # 0s
+            li      t4,   0x2000000000    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 4:  MPRV=0, MPP=00, MBE=1, UBE=1
+            li      t3,   0x21800         # 0s
+            li      t4,   0x2000000040    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 5:  MPRV=0, MPP=11, MBE=0, UBE=0
+            li      t3,   0x2000020040    # 0s
+            li      t4,   0x1800          # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 6:  MPRV=0, MPP=11, MBE=0, UBE=1
+            li      t3,   0x2000020000    # 0s
+            li      t4,   0x1840          # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 7:  MPRV=0, MPP=11, MBE=1, UBE=0
+            li      t3,   0x20040         # 0s
+            li      t4,   0x2000001800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 8:  MPRV=0, MPP=11, MBE=1, UBE=1
+            li      t3,   0x20000         # 0s
+            li      t4,   0x2000001840    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 9:  MPRV=1, MPP=00, MBE=0, UBE=0
+            li      t3,   0x2000001840    # 0s
+            li      t4,   0x20000         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 10: MPRV=1, MPP=00, MBE=0, UBE=1
+            li      t3,   0x2000001800    # 0s
+            li      t4,   0x20040         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 11: MPRV=1, MPP=00, MBE=1, UBE=0
+            li      t3,   0x1840          # 0s
+            li      t4,   0x2000020000    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 12: MPRV=1, MPP=00, MBE=1, UBE=1
+            li      t3,   0x1800          # 0s
+            li      t4,   0x2000020040    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 13: MPRV=1, MPP=11, MBE=0, UBE=0
+            li      t3,   0x2000000040    # 0s
+            li      t4,   0x21800         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 14: MPRV=1, MPP=11, MBE=0, UBE=1
+            li      t3,   0x2000000000    # 0s
+            li      t4,   0x21840         # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 15: MPRV=1, MPP=11, MBE=1, UBE=0
+            li      t3,   0x40            # 0s
+            li      t4,   0x2000021800    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            // 16: MPRV=1, MPP=11, MBE=1, UBE=1
+            li      t3,   0x0             # 0s
+            li      t4,   0x2000021840    # 1s
+            csrrc   t6, mstatus, t3       # setting the 0s
+            csrrs   t6, mstatus, t4       # setting the 1s
+            csrr    t4, mstatus           # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            jal s7, endianread2
+            j postendian2
+        #elif __riscv_xlen == 32
+        csrr s1, mstatush
+        //16 WRITES:
+            // 1:  MPRV=0, MPP=00, MBE=0, UBE=0
+            li      t3, 0x21840       # 0s -> mstatus
+            li      t4, 0x0           # 1s -> mstatus
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x00          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 2:  MPRV=0, MPP=00, MBE=0, UBE=1
+            li      t3, 0x21800       # 0s
+            li      t4, 0x40          # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 3:  MPRV=0, MPP=00, MBE=1, UBE=0
+            li      t3, 0x21840       # 0s
+            li      t4, 0x0           # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 4:  MPRV=0, MPP=00, MBE=1, UBE=1
+            li      t3, 0x21800       # 0s
+            li      t4, 0x40          # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 5:  MPRV=0, MPP=11, MBE=0, UBE=0
+            li      t3, 0x20040       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 6:  MPRV=0, MPP=11, MBE=0, UBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1840        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 7:  MPRV=0, MPP=11, MBE=1, UBE=0
+            li      t3, 0x20040       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 8:  MPRV=0, MPP=11, MBE=1, UBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1840        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 9:  MPRV=1, MPP=00, MBE=0, UBE=0
+            li      t3, 0x1840        # 0s
+            li      t4, 0x20000       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 10: MPRV=1, MPP=00, MBE=0, UBE=1
+            li      t3, 0x1800        # 0s
+            li      t4, 0x20040       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 11: MPRV=1, MPP=00, MBE=1, UBE=0
+            li      t3, 0x1840        # 0s
+            li      t4, 0x20000       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 12: MPRV=1, MPP=00, MBE=1, UBE=1
+            li      t3, 0x1800        # 0s
+            li      t4, 0x20040       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 13: MPRV=1, MPP=11, MBE=0, UBE=0
+            li      t3, 0x40          # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 14: MPRV=1, MPP=11, MBE=0, UBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21840       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 15: MPRV=1, MPP=11, MBE=1, UBE=0
+            li      t3, 0x40          # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+            // 16: MPRV=1, MPP=11, MBE=1, UBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21840       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s6, endianwrite2
+        // 16 READS:
+            // 1:  MPRV=0, MPP=00, MBE=0, UBE=0
+            li      t3, 0x21840       # 0s -> mstatus
+            li      t4, 0x0           # 1s -> mstatus
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x00          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 2:  MPRV=0, MPP=00, MBE=0, UBE=1
+            li      t3, 0x21800       # 0s
+            li      t4, 0x40          # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 3:  MPRV=0, MPP=00, MBE=1, UBE=0
+            li      t3, 0x21840       # 0s
+            li      t4, 0x0           # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 4:  MPRV=0, MPP=00, MBE=1, UBE=1
+            li      t3, 0x21800       # 0s
+            li      t4, 0x40          # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 5:  MPRV=0, MPP=11, MBE=0, UBE=0
+            li      t3, 0x20040       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 6:  MPRV=0, MPP=11, MBE=0, UBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1840        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 7:  MPRV=0, MPP=11, MBE=1, UBE=0
+            li      t3, 0x20040       # 0s
+            li      t4, 0x1800        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 8:  MPRV=0, MPP=11, MBE=1, UBE=1
+            li      t3, 0x20000       # 0s
+            li      t4, 0x1840        # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 9:  MPRV=1, MPP=00, MBE=0, UBE=0
+            li      t3, 0x1840        # 0s
+            li      t4, 0x20000       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 10: MPRV=1, MPP=00, MBE=0, UBE=1
+            li      t3, 0x1800        # 0s
+            li      t4, 0x20040       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            //11: MPRV=1, MPP=00, MBE=1, UBE=0
+            li      t3, 0x1840        # 0s
+            li      t4, 0x20000       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 12: MPRV=1, MPP=00, MBE=1, UBE=1
+            li      t3, 0x1800        # 0s
+            li      t4, 0x20040       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 13: MPRV=1, MPP=11, MBE=0, UBE=0
+            li      t3, 0x40          # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 14: MPRV=1, MPP=11, MBE=0, UBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21840       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x20          # 0s -> mstatush
+            li      t2, 0x0           # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 15: MPRV=1, MPP=11, MBE=1, UBE=0
+            li      t3, 0x40          # 0s
+            li      t4, 0x21800       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush      # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            // 16: MPRV=1, MPP=11, MBE=1, UBE=1
+            li      t3, 0x0           # 0s
+            li      t4, 0x21840       # 1s
+            csrrc   t6, mstatus, t3   # setting the 0s
+            csrrs   t6, mstatus, t4   # setting the 1s
+            csrr    t4, mstatus       # save mstatus
+            RVTEST_SIGWRITE(x3, t4) 
+            li      t1, 0x0           # 0s -> mstatush
+            li      t2, 0x20          # 1s -> mstatush
+            csrrc   t6, mstatush, t1  # setting the 0s
+            csrrs   t6, mstatush, t2  # setting the 1s
+            csrr    t2, mstatush       # save mstatush
+            RVTEST_SIGWRITE(x3, t2) 
+            jal s7, endianread2
+            j postendian2
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+
+
+endianwrite2:
+    // Try each size of stores with the write endianness
+    // Test storing bytes
+    li t0, 0x01
+    sb t0, 0(s3)
+    lb t3, 0(s3)          
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x02
+    sb t0, 1(s3)
+    lb t3, 1(s3)          
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x03
+    sb t0, 2(s3)
+    lb t3, 2(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x04
+    sb t0, 3(s3)
+    lb t3, 3(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x05
+    sb t0, 4(s3)
+    lb t3, 4(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x06
+    sb t0, 5(s3)
+    lb t3, 5(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x07
+    sb t0, 6(s3)
+    lb t3, 6(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x08
+    sb t0, 7(s3)
+    lb t3, 7(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1112
+    sh t0, 0(s3)
+    lh t3, 0(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1314
+    sh t0, 2(s3)
+    lh t3, 2(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1516
+    sh t0, 4(s3)
+    lh t3, 4(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x1718
+    sh t0, 6(s3)
+    lh t3, 6(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x21222324
+    sw t0, 0(s3)
+    lw t3, 0(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    li t0, 0x25262728
+    sw t0, 4(s3)
+    lw t3, 4(s3) 
+    RVTEST_SIGWRITE(x3, t3)
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            li t0, 0x3132333435363738
+            sd t0, 0(s3)            # sd only in RV64
+            ld t3, 0(s3) 
+            RVTEST_SIGWRITE(x3, t3)
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    jr s6   # return (return address was stored in s6)
+
+
+endianread2:
+    // loads with the read endianness
+    // Try all the accesses to make sure they work for the endianness
+    li  t0, 0x01
+    sb  t0, 0(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    li  t0, 0x02
+    sb  t0, 1(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    li  t0, 0x03
+    sb  t0, 2(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    li  t0, 0x04
+    sb  t0, 3(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    li  t0, 0x05
+    sb  t0, 4(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    li  t0, 0x06
+    sb  t0, 5(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    li  t0, 0x07
+    sb  t0, 6(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    li  t0, 0x08
+    sb  t0, 7(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 0(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 1(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 2(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 3(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 4(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 5(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 6(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lb  t0, 7(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 0(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 1(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 2(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 3(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 4(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 5(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 6(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lbu t0, 7(s3)
+    RVTEST_SIGWRITE(x3, t0)
+    lh  t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lh  t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lh  t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lh  t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lhu t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lhu t3, 2(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lhu t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lhu t3, 6(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lw  t3, 0(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    lw  t3, 4(s3)
+    RVTEST_SIGWRITE(x3, t3)
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 64
+            lwu t3, 0(s3) # long loads for RV64
+            RVTEST_SIGWRITE(x3, t3)
+            lwu t3, 4(s3)
+            RVTEST_SIGWRITE(x3, t3)
+            ld  t3, 0(s3)
+            RVTEST_SIGWRITE(x3, t3)
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+    jr s7   # return (return address was stored in s7)
+
+postendian2:
+    csrrw t6, mstatus, s0    # restore CSR
+    //restoring mstatush if rv32
+    #ifdef __riscv_xlen
+        #if __riscv_xlen == 32
+            csrrw t5, mstatush, s1
+        #endif
+    #else
+        ERROR: __riscv_xlen not defined
+    #endif
+
+
+jal s6, test_end
+
+#include "priv-endian.h"
+test_end: //finish
+
+
+
+#endif
+
+ # ---------------------------------------------------------------------------------------------
+    # HALT
+
+RVTEST_CODE_END
+RVMODEL_HALT
+
+# Allocate scratch memory in .bss section
+.section .bss
+.align 4
+scratch:
+    .space 136  # Reserve 136 bytes of uninitialized memory
+
+
+RVTEST_DATA_BEGIN
+# Input data section.
+.data
+.align 4
+rvtest_data:
+.word 0xb0bacafe
+.word 0xb0bacafe
+RVTEST_DATA_END
+
+# Output data section.
+RVMODEL_DATA_BEGIN
+rvtest_sig_begin:
+sig_begin_canary:
+CANARY;
+signature_base:
+    .fill 1300*(XLEN/32),4,0xdeadbeef
+    
+# test_A_res:
+#     .fill 2, 4, 0xdeadbeef
+
+#ifdef rvtest_mtrap_routine
+tsig_begin_canary:
+CANARY;
+mtrap_sigptr:
+    .fill 200*(XLEN/32),4,0xb0bacafe
+tsig_end_canary:
+CANARY;
+
+#endif
+
+#ifdef rvtest_gpr_save
+gpr_save:
+  .fill 32*(XLEN/32), 4, 0xdeadbeef
+#endif
+
+
+
+sig_end_canary:
+CANARY;
+rvtest_sig_end:
+RVMODEL_DATA_END
+


### PR DESCRIPTION
1. Added new macros into test_macros.h: RVTEST_SIGWRITE and RVTEST_SIGWRITE_F. 


2. Added signature logic for all endian files and the shared file. 
Currently Sail does not support Endianness and Spike currently has the option to boot in either big or little endian mode, but it can’t be changed while running. Thus coverage is currently very low. 

Jordan Carlin's message about this issue:
The whole point of the test is to ensure the processor works in both little and big endian mode, and some designs (like Wally) can switch live. Sail will eventually support runtime switching as well. If a processor doesn’t support it then it will just run the test twice with the same endianness, and as long as the reference model is configured to match it will still pass. 
