### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/crd.md
+++ b/.github/ISSUE_TEMPLATE/crd.md
@@ -1,0 +1,10 @@
+---
+name: CRD
+about: Report an issue with or suggest an improvement to the CTP
+title: "[CRD] "
+labels: CRD, documentation
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/ctp.md
+++ b/.github/ISSUE_TEMPLATE/ctp.md
@@ -1,0 +1,10 @@
+---
+name: CTP
+about: Report an issue with or suggest an improvement to the CTP
+title: "[CTP] "
+labels: CTP, documentation
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/test-bug.md
+++ b/.github/ISSUE_TEMPLATE/test-bug.md
@@ -1,0 +1,20 @@
+---
+name: Test bug
+about: Report an issue with a specific test (wrong expected results, illegal instructions,
+  missing an edge case, etc.)
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Test name**
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/test-framework-bug.md
+++ b/.github/ISSUE_TEMPLATE/test-framework-bug.md
@@ -1,0 +1,23 @@
+---
+name: Test Framework Bug
+about: Report an issue with the test framework (unable to run  the framework, wrong
+  tests selected, test compilation problems, etc.)
+title: ''
+labels: bug, Test Framework
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. On commit A,
+1. Run '...'
+
+**Text output/Error Messages**
+If any
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Issue templates that automatically apply labels for common types of issues:
- CTP bugs/suggestions
- CRD bugs/suggestions
- Test framework bugs
- Test bugs
- Feature requests